### PR TITLE
Mp filter fix

### DIFF
--- a/src/components/filter/LedenlijstFilterblok.vue
+++ b/src/components/filter/LedenlijstFilterblok.vue
@@ -86,7 +86,8 @@
                   @deactivateCriterium="deactivateCriterium"
                   v-if="criteria.criteriaKey === 'adresgeblokkeerd' || criteria.criteriaKey === 'verminderdLidgeld'
                   || criteria.criteriaKey === 'emailgeblokkeerd'    || criteria.criteriaKey === 'emailleeg'
-                  || criteria.criteriaKey === 'geenLidkaart'        || criteria.criteriaKey === 'geweigerdLid'">
+                  || criteria.criteriaKey === 'geenLidkaart'        || criteria.criteriaKey === 'geweigerdLid'
+                  || criteria.criteriaKey === 'rijksregisternummer'">
       </BoolFilter>
       <OudLedenSelect :criteria="criteria" v-if="criteria.criteriaKey === 'oudleden'" :value="criteria.value"
                       @deactivateCriterium="deactivateCriterium"></OudLedenSelect>

--- a/src/services/leden/Ledenlijst.js
+++ b/src/services/leden/Ledenlijst.js
@@ -171,7 +171,8 @@ export default {
                 criterium.criteriaKey === 'geweigerdLid' ||
                 criterium.criteriaKey === 'emailleeg' ||
                 criterium.criteriaKey === 'geenLidkaart' ||
-                criterium.criteriaKey === 'oudleden') {
+                criterium.criteriaKey === 'oudleden' ||
+                criterium.criteriaKey === 'rijksregisternummer') {
                 state.huidigeFilter.criteria[criterium.criteriaKey] = true;
             }
 
@@ -340,7 +341,8 @@ export default {
 
         const deactivateCriterium = (criterium) => {
             if (criterium.criteriaKey === 'adresgeblokkeerd' || criterium.criteriaKey === 'emailgeblokkeerd'
-                || criterium.criteriaKey === 'verminderdLidgeld' || criterium.criteriaKey === 'emailleeg' || criterium.criteriaKey === 'geenLidkaart' || criterium.criteriaKey === 'geweigerdLid') {
+                || criterium.criteriaKey === 'verminderdLidgeld' || criterium.criteriaKey === 'emailleeg' || criterium.criteriaKey === 'geenLidkaart' || criterium.criteriaKey === 'geweigerdLid'
+                || criterium.criteriaKey === 'rijksregisternummer') {
                 state.huidigeFilter.criteria[criterium.criteriaKey] = false;
             } else if (criterium.criteriaKey === 'geslacht' || criterium.criteriaKey === 'leeftijd' || criterium.criteriaKey === 'individuelesteekkaart' || criterium.criteriaKey === 'oudleden') {
                 state.huidigeFilter.criteria[criterium.criteriaKey] = undefined;

--- a/src/services/leden/ledenlijstFilter.js
+++ b/src/services/leden/ledenlijstFilter.js
@@ -312,19 +312,21 @@ export default {
 
         returnObj.arrCriteria.push(this.getGeweigerdeledenMenu());
 
-        returnObj.arrCriteria.push(this.getVerminderdLidgeldMenu())
+        returnObj.arrCriteria.push(this.getVerminderdLidgeldMenu());
 
-        returnObj.arrCriteria.push(this.getAdresGeblokkeerdMenu())
+        returnObj.arrCriteria.push(this.getRijksregisternummerMenu());
 
-        returnObj.arrCriteria.push(this.getEmailGeblokkeerdMenu())
+        returnObj.arrCriteria.push(this.getAdresGeblokkeerdMenu());
 
-        returnObj.arrCriteria.push(this.getLeeftijdMenu())
+        returnObj.arrCriteria.push(this.getEmailGeblokkeerdMenu());
 
-        returnObj.arrCriteria.push(this.getIndividueleSteekkaartMenu())
+        returnObj.arrCriteria.push(this.getLeeftijdMenu());
 
-        returnObj.arrCriteria.push(this.getLedenZonderLidkaartMenu())
+        returnObj.arrCriteria.push(this.getIndividueleSteekkaartMenu());
 
-        returnObj.arrCriteria.push(this.getLedenZonderMailAdresMenu())
+        returnObj.arrCriteria.push(this.getLedenZonderLidkaartMenu());
+
+        returnObj.arrCriteria.push(this.getLedenZonderMailAdresMenu());
 
         return returnObj;
     },
@@ -453,6 +455,22 @@ export default {
         }
         verminderdLidgeld.activated = false;
         return verminderdLidgeld;
+    },
+
+    getRijksregisternummerMenu() {
+        let rijksregisternummer = {
+            "title": "Rijksregisternummer",
+            "criteriaKey": "rijksregisternummer",
+            "multiplePossible": false,
+            "items": [
+                {
+                    "value": true,
+                    "label": "Ja"
+                }
+            ]
+        }
+        rijksregisternummer.activated = false;
+        return rijksregisternummer;
     },
 
     getEmailGeblokkeerdMenu() {


### PR DESCRIPTION
We willen graag een filter toevoegen op het rijksregisternummer, waarbij een boolean aangeeft of een lid zijn rijksregisternummer al heeft ingevuld.

Deze functionaliteit maakt het voor ons – en waarschijnlijk ook voor veel andere organisaties – eenvoudiger om na te gaan welke leden hun rijksregisternummer nog niet hebben opgegeven. 

Op die manier kunnen we gerichter opvolgen en ervoor zorgen dat iedereen tijdig zijn gegevens aanvult. 