### PR TITLE
Fix: Voorkom dataverlies in Erkenningsinstantie bij pagina refresh

### DIFF
--- a/src/components/groep/Erkenningsinstantie.vue
+++ b/src/components/groep/Erkenningsinstantie.vue
@@ -58,7 +58,8 @@
 <script>
 import GemeenteZoekAutoComplete from "@/components/adres/GemeenteZoekAutoComplete";
 import StraatZoekAutoComplete from "@/components/adres/StraatZoekAutoComplete";
-import {reactive, toRefs, watch} from "@vue/reactivity";
+import {reactive, toRefs} from "@vue/reactivity";
+import {watch} from "vue";
 import BaseInput from "@/components/input/BaseInput";
 
 export default {

--- a/src/components/groep/Erkenningsinstantie.vue
+++ b/src/components/groep/Erkenningsinstantie.vue
@@ -58,8 +58,7 @@
 <script>
 import GemeenteZoekAutoComplete from "@/components/adres/GemeenteZoekAutoComplete";
 import StraatZoekAutoComplete from "@/components/adres/StraatZoekAutoComplete";
-import {reactive, toRefs} from "@vue/reactivity";
-import {onUpdated} from "@vue/runtime-core";
+import {reactive, toRefs, watch} from "@vue/reactivity";
 import BaseInput from "@/components/input/BaseInput";
 
 export default {
@@ -99,23 +98,21 @@ export default {
       }
     });
 
-    onUpdated(() => {
-      if(props.modelValue)
-        state.instantie = props.modelValue;
-      else
-        state.instantie = {
-          naam: "",
-          kbo: "",
-          adres: {
-            bus: "",
-            gemeente: "",
-            land: "BE",
-            nummer: "",
-            postcode: "",
-            straat: ""
-          }
-        };
-    });
+    // Initialize with modelValue if available
+    if (props.modelValue) {
+      state.instantie = props.modelValue;
+    }
+
+    // Watch for prop changes and only update when modelValue has actual data
+    watch(
+      () => props.modelValue,
+      (newValue) => {
+        if (newValue && (newValue.naam || newValue.kbo || newValue.adres)) {
+          state.instantie = newValue;
+        }
+      },
+      { deep: true }
+    );
 
     const capitalize = () => {
       if (state.instantie.adres.bus) {

--- a/src/views/Groep.vue
+++ b/src/views/Groep.vue
@@ -46,8 +46,6 @@
                 ></Contacten>
                 <Erkenningsinstantie
                   v-model="selectedGroep.instantie"
-                  :groep="selectedGroep"
-                  :instantie="selectedGroep.instantie"
                   :bewerkbaar="kanGroepWijzigen"
                 ></Erkenningsinstantie>
               </div>


### PR DESCRIPTION
We merkten bij het indienen van de fiscale attesten dat de gegevens van de erkenningsinstantie (naam, adres, KBO) soms verdwenen na het refreshen van de Groep-pagina.

De oorzaak was het gebruik van de onUpdated() lifecycle hook in het Erkenningsinstantie-component om modelValue te synchroniseren met de lokale state. Omdat deze hook bij elke update loopt, ook tijdens het laden wanneer modelValue tijdelijk undefined kan zijn, werden de gegevens soms overschreven met lege waarden.

Oplossing:
- onUpdated() vervangen door watch() zodat alleen gereageerd wordt op echte wijzigingen van modelValue
- Guard toegevoegd om enkel te updaten wanneer er geldige data is
- Redundante props (:groep en :instantie) verwijderd uit Groep.vue, aangezien v-model volstaat

Ik kan dit momenteel niet testen zonder backend, maar hetzelfde patroon wordt al elders in de repo gebruikt, dus ik verwacht dat dit correct werkt.

Stevige Linker,
Maxim Peeters
Groepsleiding Scouts en Gidsen Retie